### PR TITLE
Removed us.blastingnews.com from json

### DIFF
--- a/sources/sources.json
+++ b/sources/sources.json
@@ -4607,12 +4607,6 @@
     "3rd type" : "",
     "Source Notes (things to know?)" : ""
   },
-  "us.blastingnews.com" : {
-    "type" : "satire",
-    "2nd type" : "unreliable",
-    "3rd type" : "",
-    "Source Notes (things to know?)" : ""
-  },
   "waterfordwhispersnews.com" : {
     "type" : "satire",
     "2nd type" : "",


### PR DESCRIPTION
I removed the website because it is not considered unreliable anymore on the official Melissa Zimdars' list: https://docs.google.com/document/d/10eA5-mCZLSS4MQY5QGb5ewC3VAL6pLkT53V_81ZyitM/preview and https://isitfakenews.com/search/us.blastingnews.com